### PR TITLE
Bugfix/Rename extraction module types

### DIFF
--- a/server/src/completion.ts
+++ b/server/src/completion.ts
@@ -22,12 +22,12 @@ let extractionModules = [
 ]
 
 let extractionModuleType = [
-	'CORE',
-	'AWT',
-	'DATA',
-	'EVENT',
-	'JAVAFX',
-	'OPENGL'
+	'core',
+	'awt',
+	'data',
+	'event',
+	'javafx',
+	'opengl'
 ]
 
 let currentCompletionClass = `PApplet`


### PR DESCRIPTION
Use lower-case for case-sensitive Ubuntu. Should fix #13