### PR TITLE
Feature: make suitable for windows

### DIFF
--- a/assets/SETUP.md
+++ b/assets/SETUP.md
@@ -12,6 +12,19 @@
 - To run a Processing sketch - hit `Shift+cmd+P` and enter `Run Processing Sketch` and hit enter.
 - This should run the Processing Sketch.
 
+
+# required packages/software
+## Linux/Ubuntu 
+
+- nodejs 
+- npm 
+- open-jdk 
+
+```
+sudo apt install npm
+sudo apt install nodejs
+sudo apt install openjdk-11-jdk-headless
+```
 ## Issues
 
 - If you run into any issues, make sure to raise an Issue.

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4,6 +4,12 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@tootallnate/once": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+			"dev": true
+		},
 		"agent-base": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
@@ -13,65 +19,11 @@
 				"es6-promisify": "^5.0.0"
 			}
 		},
-		"ajv": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
-			"dev": true,
-			"requires": {
-				"fast-deep-equal": "^2.0.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
-			}
-		},
-		"asn1": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-			"dev": true,
-			"requires": {
-				"safer-buffer": "~2.1.0"
-			}
-		},
-		"assert-plus": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-			"dev": true
-		},
-		"asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-			"dev": true
-		},
-		"aws-sign2": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-			"dev": true
-		},
-		"aws4": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-			"dev": true
-		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
-		},
-		"bcrypt-pbkdf": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-			"dev": true,
-			"requires": {
-				"tweetnacl": "^0.14.3"
-			}
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -83,37 +35,10 @@
 				"concat-map": "0.0.1"
 			}
 		},
-		"browser-stdout": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
-			"dev": true
-		},
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-			"dev": true
-		},
-		"caseless": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-			"dev": true
-		},
-		"combined-stream": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
-			"dev": true,
-			"requires": {
-				"delayed-stream": "~1.0.0"
-			}
-		},
-		"commander": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
 			"dev": true
 		},
 		"concat-map": {
@@ -122,21 +47,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"core-util-is": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
-		},
-		"dashdash": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
-		},
 		"debug": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -144,28 +54,6 @@
 			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
-			}
-		},
-		"delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"dev": true
-		},
-		"diff": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-			"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
-			"dev": true
-		},
-		"ecc-jsbn": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-			"dev": true,
-			"requires": {
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.1.0"
 			}
 		},
 		"es6-promise": {
@@ -189,61 +77,11 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 			"dev": true
 		},
-		"extend": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-			"dev": true
-		},
-		"extsprintf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"dev": true
-		},
-		"fast-deep-equal": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-			"dev": true
-		},
-		"fast-json-stable-stringify": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-			"dev": true
-		},
-		"forever-agent": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-			"dev": true
-		},
-		"form-data": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-			"dev": true,
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.6",
-				"mime-types": "^2.1.12"
-			}
-		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
-		},
-		"getpass": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
 		},
 		"glob": {
 			"version": "7.1.4",
@@ -259,34 +97,6 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
-		"growl": {
-			"version": "1.10.3",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
-			"dev": true
-		},
-		"har-schema": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-			"dev": true
-		},
-		"har-validator": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-			"dev": true,
-			"requires": {
-				"ajv": "^6.5.5",
-				"har-schema": "^2.0.0"
-			}
-		},
-		"has-flag": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-			"dev": true
-		},
 		"he": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -301,17 +111,6 @@
 			"requires": {
 				"agent-base": "4",
 				"debug": "3.1.0"
-			}
-		},
-		"http-signature": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
 			}
 		},
 		"https-proxy-agent": {
@@ -351,69 +150,6 @@
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 			"dev": true
 		},
-		"is-typedarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-			"dev": true
-		},
-		"isstream": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-			"dev": true
-		},
-		"jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true
-		},
-		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-			"dev": true
-		},
-		"json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
-		},
-		"json-stringify-safe": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-			"dev": true
-		},
-		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "1.0.0",
-				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
-				"verror": "1.10.0"
-			}
-		},
-		"mime-db": {
-			"version": "1.40.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
-			"dev": true
-		},
-		"mime-types": {
-			"version": "2.1.24",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-			"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-			"dev": true,
-			"requires": {
-				"mime-db": "1.40.0"
-			}
-		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -438,50 +174,10 @@
 				"minimist": "0.0.8"
 			}
 		},
-		"mocha": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
-			"integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
-			"dev": true,
-			"requires": {
-				"browser-stdout": "1.3.0",
-				"commander": "2.11.0",
-				"debug": "3.1.0",
-				"diff": "3.3.1",
-				"escape-string-regexp": "1.0.5",
-				"glob": "7.1.2",
-				"growl": "1.10.3",
-				"he": "1.1.1",
-				"mkdirp": "0.5.1",
-				"supports-color": "4.4.0"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				}
-			}
-		},
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true
-		},
-		"oauth-sign": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
 			"dev": true
 		},
 		"once": {
@@ -497,82 +193,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
-		},
-		"performance-now": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-			"dev": true
-		},
-		"psl": {
-			"version": "1.1.31",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
-			"dev": true
-		},
-		"punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true
-		},
-		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-			"dev": true
-		},
-		"querystringify": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-			"integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
-			"dev": true
-		},
-		"request": {
-			"version": "2.88.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-			"dev": true,
-			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.8.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.6",
-				"extend": "~3.0.2",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.2",
-				"har-validator": "~5.1.0",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.2",
-				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.4.3",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
-			}
-		},
-		"requires-port": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-			"dev": true
-		},
-		"safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
 		},
 		"semver": {
@@ -597,101 +217,6 @@
 				"source-map": "^0.6.0"
 			}
 		},
-		"sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-			"dev": true,
-			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
-			}
-		},
-		"supports-color": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-			"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-			"dev": true,
-			"requires": {
-				"has-flag": "^2.0.0"
-			}
-		},
-		"tough-cookie": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-			"dev": true,
-			"requires": {
-				"psl": "^1.1.24",
-				"punycode": "^1.4.1"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true
-				}
-			}
-		},
-		"tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"tweetnacl": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true
-		},
-		"uri-js": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-			"dev": true,
-			"requires": {
-				"punycode": "^2.1.0"
-			}
-		},
-		"url-parse": {
-			"version": "1.4.7",
-			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-			"integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
-			"dev": true,
-			"requires": {
-				"querystringify": "^2.1.1",
-				"requires-port": "^1.0.0"
-			}
-		},
-		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-			"dev": true
-		},
-		"verror": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
-			}
-		},
 		"vscode": {
 			"version": "1.1.37",
 			"resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.37.tgz",
@@ -705,6 +230,142 @@
 				"semver": "^5.4.1",
 				"source-map-support": "^0.5.0",
 				"vscode-test": "^0.4.1"
+			},
+			"dependencies": {
+				"agent-base": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+					"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+					"dev": true,
+					"requires": {
+						"debug": "4"
+					}
+				},
+				"browser-stdout": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+					"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+					"dev": true
+				},
+				"commander": {
+					"version": "2.15.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+					"dev": true
+				},
+				"debug": {
+					"version": "4.3.4",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"diff": {
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+					"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+					"dev": true
+				},
+				"growl": {
+					"version": "1.10.5",
+					"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+					"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"http-proxy-agent": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+					"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+					"dev": true,
+					"requires": {
+						"@tootallnate/once": "1",
+						"agent-base": "6",
+						"debug": "4"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+					"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+					"dev": true,
+					"requires": {
+						"agent-base": "6",
+						"debug": "4"
+					}
+				},
+				"mocha": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+					"integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+					"dev": true,
+					"requires": {
+						"browser-stdout": "1.3.1",
+						"commander": "2.15.1",
+						"debug": "3.1.0",
+						"diff": "3.5.0",
+						"escape-string-regexp": "1.0.5",
+						"glob": "7.1.2",
+						"growl": "1.10.5",
+						"he": "1.1.1",
+						"minimatch": "3.0.4",
+						"mkdirp": "0.5.1",
+						"supports-color": "5.4.0"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+							"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+							"dev": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"glob": {
+							"version": "7.1.2",
+							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+							"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+							"dev": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						},
+						"ms": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+							"dev": true
+						}
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"vscode-jsonrpc": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,8 +1,435 @@
 {
 	"name": "processing-lsp-client",
 	"version": "0.0.1",
-	"lockfileVersion": 1,
+	"lockfileVersion": 2,
 	"requires": true,
+	"packages": {
+		"": {
+			"name": "processing-lsp-client",
+			"version": "0.0.1",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"vscode-languageclient": "^4.1.4"
+			},
+			"devDependencies": {
+				"vscode": "^1.1.34"
+			},
+			"engines": {
+				"vscode": "^1.60.0"
+			}
+		},
+		"node_modules/agent-base": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+			"integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+			"dev": true,
+			"dependencies": {
+				"es6-promisify": "^5.0.0"
+			},
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/browser-stdout": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+			"dev": true
+		},
+		"node_modules/buffer-from": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
+		},
+		"node_modules/commander": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+			"dev": true
+		},
+		"node_modules/concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"node_modules/debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/diff": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+			"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/es6-promise": {
+			"version": "4.2.6",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+			"integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
+			"dev": true
+		},
+		"node_modules/es6-promisify": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"dev": true,
+			"dependencies": {
+				"es6-promise": "^4.0.3"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"node_modules/glob": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"dev": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/growl": {
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.x"
+			}
+		},
+		"node_modules/has-flag": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/he": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+			"dev": true,
+			"bin": {
+				"he": "bin/he"
+			}
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+			"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "4",
+				"debug": "3.1.0"
+			},
+			"engines": {
+				"node": ">= 4.5.0"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "^4.3.0",
+				"debug": "^3.1.0"
+			},
+			"engines": {
+				"node": ">= 4.5.0"
+			}
+		},
+		"node_modules/https-proxy-agent/node_modules/agent-base": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+			"dev": true,
+			"dependencies": {
+				"es6-promisify": "^5.0.0"
+			},
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
+		},
+		"node_modules/minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/minimist": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
+		},
+		"node_modules/mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+			"dev": true,
+			"dependencies": {
+				"minimist": "0.0.8"
+			},
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			}
+		},
+		"node_modules/mocha": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+			"integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+			"dev": true,
+			"dependencies": {
+				"browser-stdout": "1.3.0",
+				"commander": "2.11.0",
+				"debug": "3.1.0",
+				"diff": "3.3.1",
+				"escape-string-regexp": "1.0.5",
+				"glob": "7.1.2",
+				"growl": "1.10.3",
+				"he": "1.1.1",
+				"mkdirp": "0.5.1",
+				"supports-color": "4.4.0"
+			},
+			"bin": {
+				"_mocha": "bin/_mocha",
+				"mocha": "bin/mocha"
+			},
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/mocha/node_modules/glob": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"dev": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/semver": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+			"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-support": {
+			"version": "0.5.12",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+			"integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+			"dev": true,
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+			"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/vscode": {
+			"version": "1.1.37",
+			"resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.37.tgz",
+			"integrity": "sha512-vJNj6IlN7IJPdMavlQa1KoFB3Ihn06q1AiN3ZFI/HfzPNzbKZWPPuiU+XkpNOfGU5k15m4r80nxNPlM7wcc0wg==",
+			"deprecated": "This package is deprecated in favor of @types/vscode and vscode-test. For more information please read: https://code.visualstudio.com/updates/v1_36#_splitting-vscode-package-into-typesvscode-and-vscodetest",
+			"dev": true,
+			"dependencies": {
+				"glob": "^7.1.2",
+				"http-proxy-agent": "^4.0.1",
+				"https-proxy-agent": "^5.0.0",
+				"mocha": "^5.2.0",
+				"semver": "^5.4.1",
+				"source-map-support": "^0.5.0",
+				"vscode-test": "^0.4.1"
+			},
+			"bin": {
+				"vscode-install": "bin/install"
+			},
+			"engines": {
+				"node": ">=8.9.3"
+			}
+		},
+		"node_modules/vscode-jsonrpc": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.6.2.tgz",
+			"integrity": "sha512-T24Jb5V48e4VgYliUXMnZ379ItbrXgOimweKaJshD84z+8q7ZOZjJan0MeDe+Ugb+uqERDVV8SBmemaGMSMugA==",
+			"engines": {
+				"node": ">=4.0.0 || >=6.0.0"
+			}
+		},
+		"node_modules/vscode-languageclient": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-4.1.4.tgz",
+			"integrity": "sha512-V2fWd+2vm8wmShjgciBxovMzSXMzBFtQo2R6OIW5kJIynds6x0J3SwMNa3QKAmhsCDy3WmBwnplBGtyGNNnvPA==",
+			"dependencies": {
+				"vscode-languageserver-protocol": "^3.7.2"
+			},
+			"engines": {
+				"vscode": "^1.22"
+			}
+		},
+		"node_modules/vscode-languageserver-protocol": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.7.2.tgz",
+			"integrity": "sha512-VVJwIA/FPl/FnVtrns0FPK6TLi/ET7n1Yo6tCrm6aG7+yAVwIGWdpTmKE+nbP8wEMMbHCkIabk63IJvfz2HNRg==",
+			"dependencies": {
+				"vscode-jsonrpc": "^3.6.2",
+				"vscode-languageserver-types": "^3.7.2"
+			}
+		},
+		"node_modules/vscode-languageserver-types": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.7.2.tgz",
+			"integrity": "sha512-L9D2RA+PDS2CiyhLQY5ZrOmyRvXyjc4Ha8s9PqS6mIgGxj00R5Xx2vLKBnAOVfrawJXYZST+2hioMks6SQVU7A=="
+		},
+		"node_modules/vscode-test": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.1.tgz",
+			"integrity": "sha512-uIi/07uG/gmCbD9Y9bFpNzmk4el82xiclijEdL426A3jOFfvwdqgfmtuWYfxEGo0w6JY9EqVDTGQCXwuInXVTQ==",
+			"deprecated": "This package has been renamed to @vscode/test-electron, please update to the new name",
+			"dev": true,
+			"dependencies": {
+				"http-proxy-agent": "^2.1.0",
+				"https-proxy-agent": "^2.2.1"
+			},
+			"engines": {
+				"node": ">=8.9.3"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		}
+	},
 	"dependencies": {
 		"agent-base": {
 			"version": "4.2.1",
@@ -13,65 +440,11 @@
 				"es6-promisify": "^5.0.0"
 			}
 		},
-		"ajv": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
-			"dev": true,
-			"requires": {
-				"fast-deep-equal": "^2.0.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
-			}
-		},
-		"asn1": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-			"dev": true,
-			"requires": {
-				"safer-buffer": "~2.1.0"
-			}
-		},
-		"assert-plus": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-			"dev": true
-		},
-		"asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-			"dev": true
-		},
-		"aws-sign2": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-			"dev": true
-		},
-		"aws4": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-			"dev": true
-		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
-		},
-		"bcrypt-pbkdf": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-			"dev": true,
-			"requires": {
-				"tweetnacl": "^0.14.3"
-			}
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -95,21 +468,6 @@
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
 			"dev": true
 		},
-		"caseless": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-			"dev": true
-		},
-		"combined-stream": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
-			"dev": true,
-			"requires": {
-				"delayed-stream": "~1.0.0"
-			}
-		},
 		"commander": {
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
@@ -122,21 +480,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"core-util-is": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
-		},
-		"dashdash": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
-		},
 		"debug": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -146,27 +489,11 @@
 				"ms": "2.0.0"
 			}
 		},
-		"delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"dev": true
-		},
 		"diff": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
 			"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
 			"dev": true
-		},
-		"ecc-jsbn": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-			"dev": true,
-			"requires": {
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.1.0"
-			}
 		},
 		"es6-promise": {
 			"version": "4.2.6",
@@ -189,61 +516,11 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 			"dev": true
 		},
-		"extend": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-			"dev": true
-		},
-		"extsprintf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"dev": true
-		},
-		"fast-deep-equal": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-			"dev": true
-		},
-		"fast-json-stable-stringify": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-			"dev": true
-		},
-		"forever-agent": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-			"dev": true
-		},
-		"form-data": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-			"dev": true,
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.6",
-				"mime-types": "^2.1.12"
-			}
-		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
-		},
-		"getpass": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
 		},
 		"glob": {
 			"version": "7.1.4",
@@ -265,22 +542,6 @@
 			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
 			"dev": true
 		},
-		"har-schema": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-			"dev": true
-		},
-		"har-validator": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-			"dev": true,
-			"requires": {
-				"ajv": "^6.5.5",
-				"har-schema": "^2.0.0"
-			}
-		},
 		"has-flag": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
@@ -301,17 +562,6 @@
 			"requires": {
 				"agent-base": "4",
 				"debug": "3.1.0"
-			}
-		},
-		"http-signature": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
 			}
 		},
 		"https-proxy-agent": {
@@ -351,69 +601,6 @@
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 			"dev": true
 		},
-		"is-typedarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-			"dev": true
-		},
-		"isstream": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-			"dev": true
-		},
-		"jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true
-		},
-		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-			"dev": true
-		},
-		"json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
-		},
-		"json-stringify-safe": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-			"dev": true
-		},
-		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "1.0.0",
-				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
-				"verror": "1.10.0"
-			}
-		},
-		"mime-db": {
-			"version": "1.40.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
-			"dev": true
-		},
-		"mime-types": {
-			"version": "2.1.24",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-			"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-			"dev": true,
-			"requires": {
-				"mime-db": "1.40.0"
-			}
-		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -439,8 +626,7 @@
 			}
 		},
 		"mocha": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+			"version": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
 			"integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
 			"dev": true,
 			"requires": {
@@ -478,12 +664,6 @@
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 			"dev": true
 		},
-		"oauth-sign": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-			"dev": true
-		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -497,82 +677,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
-		},
-		"performance-now": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-			"dev": true
-		},
-		"psl": {
-			"version": "1.1.31",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
-			"dev": true
-		},
-		"punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true
-		},
-		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-			"dev": true
-		},
-		"querystringify": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-			"integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
-			"dev": true
-		},
-		"request": {
-			"version": "2.88.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-			"dev": true,
-			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.8.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.6",
-				"extend": "~3.0.2",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.2",
-				"har-validator": "~5.1.0",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.2",
-				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.4.3",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
-			}
-		},
-		"requires-port": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-			"dev": true
-		},
-		"safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
 		},
 		"semver": {
@@ -597,23 +701,6 @@
 				"source-map": "^0.6.0"
 			}
 		},
-		"sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-			"dev": true,
-			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
-			}
-		},
 		"supports-color": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
@@ -621,75 +708,6 @@
 			"dev": true,
 			"requires": {
 				"has-flag": "^2.0.0"
-			}
-		},
-		"tough-cookie": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-			"dev": true,
-			"requires": {
-				"psl": "^1.1.24",
-				"punycode": "^1.4.1"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true
-				}
-			}
-		},
-		"tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"tweetnacl": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true
-		},
-		"uri-js": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-			"dev": true,
-			"requires": {
-				"punycode": "^2.1.0"
-			}
-		},
-		"url-parse": {
-			"version": "1.4.7",
-			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-			"integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
-			"dev": true,
-			"requires": {
-				"querystringify": "^2.1.1",
-				"requires-port": "^1.0.0"
-			}
-		},
-		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-			"dev": true
-		},
-		"verror": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
 			}
 		},
 		"vscode": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -693,17 +693,17 @@
 			}
 		},
 		"vscode": {
-			"version": "1.1.34",
-			"resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.34.tgz",
-			"integrity": "sha512-GuT3tCT2N5Qp26VG4C+iGmWMgg/MuqtY5G5TSOT3U/X6pgjM9LFulJEeqpyf6gdzpI4VyU3ZN/lWPo54UFPuQg==",
+			"version": "1.1.37",
+			"resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.37.tgz",
+			"integrity": "sha512-vJNj6IlN7IJPdMavlQa1KoFB3Ihn06q1AiN3ZFI/HfzPNzbKZWPPuiU+XkpNOfGU5k15m4r80nxNPlM7wcc0wg==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.2",
-				"mocha": "^4.0.1",
-				"request": "^2.88.0",
+				"http-proxy-agent": "^4.0.1",
+				"https-proxy-agent": "^5.0.0",
+				"mocha": "^5.2.0",
 				"semver": "^5.4.1",
 				"source-map-support": "^0.5.0",
-				"url-parse": "^1.4.4",
 				"vscode-test": "^0.4.1"
 			}
 		},

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
 		"url": "https://github.com/processing-language-server/LS4P"
 	},
 	"engines": {
-		"vscode": "^1.23.0"
+		"vscode": "^1.60.0"
 	},
 	"scripts": {
 		"update-vscode": "vscode-install",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,425 @@
 {
 	"name": "processing-lsp",
 	"version": "1.0.0",
-	"lockfileVersion": 1,
+	"lockfileVersion": 2,
 	"requires": true,
+	"packages": {
+		"": {
+			"name": "processing-lsp",
+			"version": "1.0.0",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"java-ast": "^0.1.0"
+			},
+			"devDependencies": {
+				"@types/mocha": "^5.2.0",
+				"@types/node": "^8.0.0",
+				"tslint": "^5.16.0",
+				"typescript": "^3.5.1"
+			},
+			"engines": {
+				"vscode": "^1.23.0"
+			}
+		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/highlight": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/highlight": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^4.0.0"
+			}
+		},
+		"node_modules/@types/mocha": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.0.tgz",
+			"integrity": "sha512-YeDiSEzznwZwwp766SJ6QlrTyBYUGPSIwmREHVTmktUYiT/WADdWtpt9iH0KuUSf8lZLdI4lP0X6PBzPo5//JQ==",
+			"dev": true
+		},
+		"node_modules/@types/node": {
+			"version": "8.10.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.18.tgz",
+			"integrity": "sha512-WoepSz+wJlU5Bjq5oK6cO1oXe2FgPcjMtQPgKPS8fVaTAD0lxkScMCCbMimdkVCsykqaA4lvHWz3cmj28yimhA==",
+			"dev": true
+		},
+		"node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/antlr4ts": {
+			"version": "0.4.1-alpha.0",
+			"resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.4.1-alpha.0.tgz",
+			"integrity": "sha1-rFcX8w8++jYXsATo/0+GC5x9TSA="
+		},
+		"node_modules/argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/builtin-modules": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"node_modules/commander": {
+			"version": "2.20.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+			"dev": true
+		},
+		"node_modules/concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"node_modules/diff": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true,
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"node_modules/glob": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"dev": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
+		},
+		"node_modules/java-ast": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/java-ast/-/java-ast-0.1.0.tgz",
+			"integrity": "sha512-xa0fksWutSf2cDlhbd6yztYbDB7cChFAk5qZcN7onsOIPxT/xUtIJy3v9wgsUhiIi5+Q4vZg0lFIr7SAkkxADg==",
+			"dependencies": {
+				"antlr4ts": "^0.4.1-alpha.0"
+			}
+		},
+		"node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
+		},
+		"node_modules/js-yaml": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/minimist": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
+		},
+		"node_modules/mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+			"dev": true,
+			"dependencies": {
+				"minimist": "0.0.8"
+			},
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
+		},
+		"node_modules/resolve": {
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
+			"integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
+			"dev": true,
+			"dependencies": {
+				"path-parse": "^1.0.6"
+			}
+		},
+		"node_modules/semver": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+			"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
+		"node_modules/sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
+		"node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/tslib": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"dev": true
+		},
+		"node_modules/tslint": {
+			"version": "5.16.0",
+			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.16.0.tgz",
+			"integrity": "sha512-UxG2yNxJ5pgGwmMzPMYh/CCnCnh0HfPgtlVRDs1ykZklufFBL1ZoTlWFRz2NQjcoEiDoRp+JyT0lhBbbH/obyA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.0.0",
+				"builtin-modules": "^1.1.1",
+				"chalk": "^2.3.0",
+				"commander": "^2.12.1",
+				"diff": "^3.2.0",
+				"glob": "^7.1.1",
+				"js-yaml": "^3.13.0",
+				"minimatch": "^3.0.4",
+				"mkdirp": "^0.5.1",
+				"resolve": "^1.3.2",
+				"semver": "^5.3.0",
+				"tslib": "^1.8.0",
+				"tsutils": "^2.29.0"
+			},
+			"bin": {
+				"tslint": "bin/tslint"
+			},
+			"engines": {
+				"node": ">=4.8.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev"
+			}
+		},
+		"node_modules/tsutils": {
+			"version": "2.29.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^1.8.1"
+			},
+			"peerDependencies": {
+				"typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+			"integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		}
+	},
 	"dependencies": {
 		"@babel/code-frame": {
 			"version": "7.0.0",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,8 +1,248 @@
 {
 	"name": "processing-lsp-client",
 	"version": "0.0.1",
-	"lockfileVersion": 1,
+	"lockfileVersion": 2,
 	"requires": true,
+	"packages": {
+		"": {
+			"name": "processing-lsp-client",
+			"version": "0.0.1",
+			"license": "MIT",
+			"dependencies": {
+				"java": "^0.12.1",
+				"java-class-tools": "^1.3.1",
+				"rxjs": "^6.6.3",
+				"vscode-languageserver": "^4.1.3"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/async": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+			"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+			"dependencies": {
+				"lodash": "^4.17.10"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/bytebuffer": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
+			"integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
+			"dependencies": {
+				"long": "~3"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"node_modules/find-java-home": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/find-java-home/-/find-java-home-0.2.0.tgz",
+			"integrity": "sha512-nq5PFOHxE1VSEbdDVkLoA2bAcRnG4ETqJO8ipFq3glIWA52hdWCXYX3emuUyMAQfaqFU4Ea85gqcgaPmOApEPA==",
+			"dependencies": {
+				"which": "~1.0.5",
+				"winreg": "~1.2.2"
+			}
+		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"node_modules/glob": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"node_modules/java": {
+			"version": "0.12.1",
+			"resolved": "https://registry.npmjs.org/java/-/java-0.12.1.tgz",
+			"integrity": "sha512-Rll5pmWImAPGmL8R2Cquq5cMtBgFcG6pvYD+/vVuV016oXfsw+jZntLybwLI18xCctDOmd0DjdL+bGh7Sh9Bsw==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"async": "2.6.1",
+				"find-java-home": "0.2.0",
+				"glob": "7.1.3",
+				"lodash": "4.17.14",
+				"nan": "2.14.0"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/java-class-tools": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/java-class-tools/-/java-class-tools-1.3.1.tgz",
+			"integrity": "sha512-mu6CMV3rSeT/8q3RNScc5Hi20sLeMRx+0oD//LqybnXUHdtQkEwxuLoduAv5bgGdvntF5ceg6DmpsVO4M9/H/w==",
+			"dependencies": {
+				"bytebuffer": "^5.0.1"
+			}
+		},
+		"node_modules/lodash": {
+			"version": "4.17.14",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+			"integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+		},
+		"node_modules/long": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+			"integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/nan": {
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/rxjs": {
+			"version": "6.6.3",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+			"integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+			"dependencies": {
+				"tslib": "^1.9.0"
+			},
+			"engines": {
+				"npm": ">=2.0.0"
+			}
+		},
+		"node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/vscode-jsonrpc": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.6.2.tgz",
+			"integrity": "sha512-T24Jb5V48e4VgYliUXMnZ379ItbrXgOimweKaJshD84z+8q7ZOZjJan0MeDe+Ugb+uqERDVV8SBmemaGMSMugA==",
+			"engines": {
+				"node": ">=4.0.0 || >=6.0.0"
+			}
+		},
+		"node_modules/vscode-languageserver": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-4.1.3.tgz",
+			"integrity": "sha512-D6p3q9x8QPtPLRUO5d2UKizjFYfg8zLVJqKoMpAaom8Wuhl1oKRCjeLg+Cp4mgPeCwR71wbgX2BM/jL51ni/0g==",
+			"dependencies": {
+				"vscode-languageserver-protocol": "^3.7.2",
+				"vscode-uri": "^1.0.1"
+			},
+			"bin": {
+				"installServerIntoExtension": "bin/installServerIntoExtension"
+			}
+		},
+		"node_modules/vscode-languageserver-protocol": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.7.2.tgz",
+			"integrity": "sha512-VVJwIA/FPl/FnVtrns0FPK6TLi/ET7n1Yo6tCrm6aG7+yAVwIGWdpTmKE+nbP8wEMMbHCkIabk63IJvfz2HNRg==",
+			"dependencies": {
+				"vscode-jsonrpc": "^3.6.2",
+				"vscode-languageserver-types": "^3.7.2"
+			}
+		},
+		"node_modules/vscode-languageserver-types": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.7.2.tgz",
+			"integrity": "sha512-L9D2RA+PDS2CiyhLQY5ZrOmyRvXyjc4Ha8s9PqS6mIgGxj00R5Xx2vLKBnAOVfrawJXYZST+2hioMks6SQVU7A=="
+		},
+		"node_modules/vscode-uri": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.3.tgz",
+			"integrity": "sha1-Yxvb9xbcyrDmUpGo3CXCMjIIWlI="
+		},
+		"node_modules/which": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+			"integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+			"bin": {
+				"which": "bin/which"
+			}
+		},
+		"node_modules/winreg": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.4.tgz",
+			"integrity": "sha1-ugZWKbepJRMOFXeRCM9UCZDpjRs="
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		}
+	},
 	"dependencies": {
 		"async": {
 			"version": "2.6.1",

--- a/server/src/completion.ts
+++ b/server/src/completion.ts
@@ -22,12 +22,12 @@ let extractionModules = [
 ]
 
 let extractionModuleType = [
-	'CORE',
-	'AWT',
-	'DATA',
-	'EVENT',
-	'JAVAFX',
-	'OPENGL'
+	'core',
+	'awt',
+	'data',
+	'event',
+	'javafx',
+	'opengl'
 ]
 
 let currentCompletionClass = `PApplet`

--- a/server/src/diagnostics.ts
+++ b/server/src/diagnostics.ts
@@ -96,11 +96,17 @@ export function cookCompilationDiagnostics(processedText: string, pwd: String){
 			tempSplit.forEach(function(line:String, index: number){
 				if(line.includes(`${pwd}`)){
 					let innerSplit = line.split(":")
+					
+					//Correct split index (OS depentend)
+					let splitIndex;
+					if (process.platform === 'win32') splitIndex = 2
+					else splitIndex = 1
+
 					// Handling line number based on current Behaviour - since preprocessing is done
 					if(preProcessingClass.defaultBehaviourEnable){
-						errorNodeLine[errorNodeCount] = +innerSplit[1] - pStandards.reduceLineDefaultBehaviour
+						errorNodeLine[errorNodeCount] = +innerSplit[splitIndex] - pStandards.reduceLineDefaultBehaviour
 					} else if(preProcessingClass.methodBehaviourEnable){
-						errorNodeLine[errorNodeCount] = +innerSplit[1] - pStandards.reduceLineMethodBehaviour
+						errorNodeLine[errorNodeCount] = +innerSplit[splitIndex] - pStandards.reduceLineMethodBehaviour
 					}
 					let localIndex = index + 1
 					errorNodeReasons[errorNodeCount] = line.split("error:")[1]

--- a/server/src/grammer/terms/preprocessingsnippets.ts
+++ b/server/src/grammer/terms/preprocessingsnippets.ts
@@ -157,7 +157,7 @@ ${settingsContext}
 function preprocessingFooter(): String{
 	let generatedFooter: String = `
 public static void main(String[] args) {
-PApplet.main(${defaultClassName});
+PApplet.main("${defaultClassName}");
 }`
 	return generatedFooter
 }

--- a/server/src/grammer/terms/preprocessingsnippets.ts
+++ b/server/src/grammer/terms/preprocessingsnippets.ts
@@ -157,7 +157,7 @@ ${settingsContext}
 function preprocessingFooter(): String{
 	let generatedFooter: String = `
 public static void main(String[] args) {
-PApplet.main(\\\"${defaultClassName}\\\");
+PApplet.main(${defaultClassName});
 }`
 	return generatedFooter
 }

--- a/server/src/parser.ts
+++ b/server/src/parser.ts
@@ -5,6 +5,7 @@ import { TextDocument } from 'vscode-languageserver';
 import * as pStandards from './grammer/terms/preprocessingsnippets'
 import * as log from './scripts/syslogs'
 const childProcess = require('child_process');
+const fs = require('fs')
 
 // Tuple -> current Node, Parent Node
 export let tokenArray: [ParseTree, ParseTree][] = new Array();
@@ -37,7 +38,7 @@ export function parseAST(processedText: string, textDocument: TextDocument) {
 	// make sure to set .classpath for Processing core as environment variable
 	// This suites for raw java case - should handle for default and setupDraw case
 	try{
-		childProcess.execSync(`echo \"${processedText}\" > ${__dirname}/compile/${pStandards.defaultClassName}.java`)
+		fs.writeFileSync(__dirname+"/compile/"+pStandards.defaultClassName+".java", processedText)
 		log.writeLog(`Java File creation successful`)
 	} catch(e) {
 		log.writeLog(`[[ERR]] - Error in Java File Creation`)

--- a/server/src/parser.ts
+++ b/server/src/parser.ts
@@ -52,10 +52,14 @@ export function parseAST(processedText: string, textDocument: TextDocument) {
 		log.writeLog(`[[ERR]] - Error in Java File Compilation`)
 	}
 
-	// Wrote methods to handle Error in the Error Stream
-	// diagnostics.cookDiagnosticsReport(processedText)
-	diagnostics.cookCompilationDiagnostics(processedText, `${__dirname}/compile/${pStandards.defaultClassName}.java`)
-
+	//Correct path for different OS's
+	let pwd
+	if (process.platform === 'win32') {
+		pwd =`${__dirname}\\compile\\${pStandards.defaultClassName}.java`
+	}else {
+		pwd = `${__dirname}/compile/${pStandards.defaultClassName}.java`
+	}
+	diagnostics.cookCompilationDiagnostics(processedText, pwd)
 
 	log.writeLog("Parse Tree construction Successfully")
 }

--- a/server/src/parser.ts
+++ b/server/src/parser.ts
@@ -5,7 +5,6 @@ import { TextDocument } from 'vscode-languageserver';
 import * as pStandards from './grammer/terms/preprocessingsnippets'
 import * as log from './scripts/syslogs'
 const childProcess = require('child_process');
-const fs = require('fs')
 
 // Tuple -> current Node, Parent Node
 export let tokenArray: [ParseTree, ParseTree][] = new Array();
@@ -38,7 +37,7 @@ export function parseAST(processedText: string, textDocument: TextDocument) {
 	// make sure to set .classpath for Processing core as environment variable
 	// This suites for raw java case - should handle for default and setupDraw case
 	try{
-		fs.writeFileSync(__dirname+"/compile/"+pStandards.defaultClassName+".java", processedText)
+		childProcess.execSync(`echo \"${processedText}\" > ${__dirname}/compile/${pStandards.defaultClassName}.java`)
 		log.writeLog(`Java File creation successful`)
 	} catch(e) {
 		log.writeLog(`[[ERR]] - Error in Java File Creation`)

--- a/server/src/preprocessing.ts
+++ b/server/src/preprocessing.ts
@@ -16,7 +16,7 @@ export let methodPattern = /[\w\<\>\[\]]+\s+(\w+) *\([^\)]*\) *(\{)/g
 export let modifiedMethodPatternStart = /[\w\<\>\[\]]+\s+(\w+) *\([^\)]*\)[ ]*/g
 export let modifiedMethodPatternEnd = /[ ]*(\{)[ ]*/g
 export let ifelsePattern = /[ ]*(else)[ ]*(if)[ ]*\(/g
-export let singleLineComment = /\/\/([ ]*([A-Za-z\"\.\(\)\'\=\<\>\!])\w*)*/g
+export let singleLineComment = /\/\/(.)*/g
 export let multiLineCommentComponents = [
 	/\/\*/g,
 	/\*\//g


### PR DESCRIPTION
LS4P should now work on Windows, updated the following:

"Run Processing Sketch" Task not executing a processing sketch
- Make file copying OS independent using fs.copyFileSync()
- OS dependent class path parameter for java execution. Windows cp should end with a ";' instead of ":"
- Set workdir directly in ChildProcess.exe trough cwd option. The execution of a cd command in windows wasn't changing the directory

No error messages were displayed in the client
-  OS dependent pwd path for [cookCompilationDiagnostics](https://github.com/Efratror/LS4P/blob/e4159faff29f08c77800ec8c0f34958674b655ff/server/src/diagnostics.ts#L77). Lines didn't include the path due to "\\" and "/" difference. 
- OS dependent split index for line number reference. Windows uses colons in it's path offsetting the line number by one in the [innersplit array](https://github.com/Efratror/LS4P/blob/e4159faff29f08c77800ec8c0f34958674b655ff/server/src/diagnostics.ts#L98)