### PR TITLE
Feature/multi tab support

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -32,7 +32,7 @@ export function activate(context: vscode.ExtensionContext) {
 	let clientOptions: LanguageClientOptions = {
 		documentSelector: [{ scheme: 'file', language: 'Processing' }],
 		synchronize: {
-			fileEvents: vscode.workspace.createFileSystemWatcher('**/.clientrc')
+			fileEvents: vscode.workspace.createFileSystemWatcher('**/*')
 		}
 	};
 

--- a/server/src/preprocessing.ts
+++ b/server/src/preprocessing.ts
@@ -5,6 +5,7 @@ import { parse } from 'java-ast'
 import { ParseTree } from 'antlr4ts/tree/ParseTree'
 import { MethodDeclarationContext } from 'java-ast/dist/parser/JavaParser';
 import * as log from './scripts/syslogs'
+import * as sketch from './sketch'
 
 export let defaultBehaviourEnable = false
 export let methodBehaviourEnable = false
@@ -23,7 +24,13 @@ export let multiLineCommentComponents = [
 ]
 
 export async function performPreProcessing(textDocument: lsp.TextDocument): Promise<void>{
-	let unProcessedText = textDocument.getText()
+	if (!sketch.initialized) {
+		sketch.initialize(textDocument);
+	}
+
+	sketch.updateContent(textDocument)
+	let unProcessedText = sketch.getContent()
+
 	let processedText: String
 	let unProcessedMethodName: RegExpExecArray | null
 	// Super set that contains all the methods in the workspace

--- a/server/src/references.ts
+++ b/server/src/references.ts
@@ -5,6 +5,7 @@ import * as pstandard from './grammer/terms/preprocessingsnippets'
 import { parse } from 'java-ast'
 import { ParseTree } from 'antlr4ts/tree/ParseTree'
 import { tokenArray } from './parser';
+import * as sketch from './sketch'
 
 let currentTempAST: [ParseTree][] = new Array();
 let _currentTempCounter = -1
@@ -48,15 +49,23 @@ export function scheduleLookUpReference(_referenceParams: ReferenceParams): Loca
 		if((word[1] <= _referenceParams.position.character) && (_referenceParams.position.character <= word[2])){
 			tokenArray.forEach(function(token){
 				if(token[0].text == word[0]){
+					let lineNumberJavaFile = token[0].payload._line-adjustOffset
+					let refLine : number = 0;
+					let docUri : string = '';
+					if (sketch.transformMap.get(lineNumberJavaFile)) {
+						refLine = sketch.transformMap.get(lineNumberJavaFile)!.lineNumber
+						let docName =  sketch.transformMap.get(lineNumberJavaFile)!.fileName
+						docUri = sketch.uri+docName
+					}
 					multipleTokenOccurenceLocations[_multipleTokenCount] = {
-						uri: _referenceParams.textDocument.uri,
+						uri: docUri,
 						range: {
 							start: {
-								line: token[0].payload._line-(adjustOffset+1),
+								line: refLine-1,
 								character: token[0].payload._charPositionInLine
 							},
 							end: {
-								line: token[0].payload._line-(adjustOffset+1),
+								line: refLine-1,
 								character: token[0].payload._charPositionInLine + word[0].length
 							}
 						}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -14,7 +14,8 @@ import {
 	Location,
 	ReferenceParams,
 	RenameParams,
-	WorkspaceEdit
+	WorkspaceEdit,
+	FileChangeType
 } from 'vscode-languageserver';
 
 import { interval, Observable, of, Subject } from 'rxjs';
@@ -28,6 +29,7 @@ import * as log from './scripts/syslogs'
 import * as definition from './definition'
 import * as lens from './lens'
 import * as reference from './references'
+import * as sketch from './sketch';
 
 export let connection = createConnection(ProposedFeatures.all);
 
@@ -159,6 +161,22 @@ function sleep(ms: number) {
 
 connection.onDidChangeWatchedFiles(_change => {
 	connection.console.log('We received an file change event');
+
+	for (let i = 0; i < _change.changes.length; i++) {
+		const change = _change.changes[i];
+		
+		switch (change.type) {
+		  case FileChangeType.Created:
+			sketch.addTab(change.uri)
+			break;
+		  case FileChangeType.Deleted:
+			sketch.removeTab(change.uri)
+			break;
+		  default:
+			// do nothing
+			break;
+		}
+	}
 });
 
 // Implementation for `goto definition` goes here

--- a/server/src/sketch.ts
+++ b/server/src/sketch.ts
@@ -91,7 +91,7 @@ export function updateContent(changedDocument: lsp.TextDocument) {
 	for (let [fileName, fileContents] of contents) {
 		fileContents += '\n'
 
-		cookTransformDict(fileName, fileContents, bigCount)
+		bigCount = cookTransformDict(fileName, fileContents, bigCount)
 	}
 
 	return true

--- a/server/src/sketch.ts
+++ b/server/src/sketch.ts
@@ -167,6 +167,38 @@ function getPathFromUri(uri : string) : string {
 }
 
 /**
+ * Appends the name and content of a .pde file (tab)
+ * to the content map of the sketch
+ * 
+ * @param uri Location to the file that needs adding
+ */
+export function addTab(uri: string) {
+	if (initialized) {
+		let fileName = pathM.basename(uri)
+		if (fileName.endsWith('.pde')) {
+			let tabContents = fs.readdirSync(path+fileName, 'utf-8')
+			contents.set(fileName, tabContents)
+		}
+	}
+}
+
+
+/**
+ * Deletes the name and content of a .pde file (tab)
+ * from the sketch content map
+ * 
+ * @param uri Location to the file that needs removing
+ */
+export function removeTab(uri: string) {
+	if (initialized) {
+		let fileName = pathM.basename(uri)
+		if (fileName.endsWith('.pde') && contents.has(fileName)) {
+			contents.delete(fileName)
+		}
+	}
+}
+
+/**
  * Transforms a path to a file uri
  * 
  * @param path Path of a file

--- a/server/src/sketch.ts
+++ b/server/src/sketch.ts
@@ -1,0 +1,180 @@
+import * as lsp from 'vscode-languageserver'
+import * as log from './scripts/syslogs'
+
+const fs = require('fs')
+const pathM = require('path')
+
+
+export let path : string = ''
+export let uri : string = ''
+export let name : string = '';
+export let contents  = new Map<string, string>()
+export let initialized = false;
+
+/** 
+ * Map which maps the line in the java file to the line in the .pde file (tab). 
+ * Index is the java file number.
+ * The interface holds the line number and name of the .pde file (tab).
+*/
+export let transformMap = new Map<number, IOriginalTab>()
+
+export interface IOriginalTab {
+	lineNumber: number;
+	fileName: string;
+}
+
+/**
+ * Initializes a sketch. 
+ * Determens the sketch folder based on the parameter
+ * 
+ * @param textDocument  .pde file(tab) in the sketch directory.
+ * @returns Creation succes state
+ */
+export function initialize(textDocument: lsp.TextDocument) {
+	
+	uri = pathM.dirname(textDocument.uri)+'/'
+	path = getPathFromUri(uri)
+	name = pathM.basename(path)
+
+	try {
+		let mainFileName = name+'.pde'
+		let mainFileContents = fs.readFileSync(path+mainFileName, 'utf-8')
+
+		contents.set(mainFileName, mainFileContents)
+	}
+	catch (e) {
+		console.log("Something went wrong while loading the main file")
+		console.log(e)
+		return false
+	}
+
+	try{
+		let fileNames = fs.readdirSync(path)
+		fileNames.forEach((fileName : string) =>{
+			if (fileName.endsWith('.pde') && !fileName.includes(name)){
+				let tabContents = fs.readFileSync(path+fileName, 'utf-8')
+				contents.set(fileName, tabContents)
+			}
+		});
+	}
+	catch(e) {
+		console.log("Some thing went wrong while loading the other files")
+		console.log(e)
+		return false
+	}
+	
+	initialized = true
+	return true
+}
+
+/**
+ * Updates the sketch based on the changed document.
+ * The tranform dict is automatically updated to the new changes
+ * 
+ * @param changedDocument Document of which the content should be updated
+ * @returns Update succes state
+ */
+export function updateContent(changedDocument: lsp.TextDocument) {
+
+	if (!initialized) {
+		return false
+	}
+
+	//Update content
+	let tabName = pathM.basename(changedDocument.uri)
+	if(tabName.endsWith('.pde')) {
+		contents.set(tabName, changedDocument.getText())
+	}
+
+	//Update transformation dict
+	let bigCount = 1
+	for (let [fileName, fileContents] of contents) {
+		fileContents += '\n'
+
+		cookTransformDict(fileName, fileContents, bigCount)
+	}
+
+	return true
+}
+
+/**
+ * Provides the current content of a sketch.
+ * 
+ * @returns sketch content
+ */
+export function getContent() : string{
+
+	if (!initialized) {
+		return ''
+	}
+
+	let content = ''
+
+	for (let [fileName, fileContents] of contents) {
+		fileContents += '\n' //Tab must end with a new line
+		content += fileContents
+	}
+
+	return content
+}
+
+/**
+ * Updates the sketch transformation map
+ * 
+ * 
+ * @param fileName Name of the .pde file (tab)
+ * @param fileContents Contents of the .pde file (tab)
+ * @param bigCount Line number in the created java file
+ * @returns 
+ */
+function cookTransformDict(fileName: string, fileContents: string, bigCount: number) : number{
+
+	// Revert big count due to new line at end of a tab
+	if (bigCount > 1) {
+		bigCount -= 1
+	}
+
+	try {
+		// Create transformation Dictonary
+		let lineCount = 1			
+		fileContents.split(/\r?\n/).forEach((line) => {
+			transformMap.set(bigCount, {lineNumber: lineCount, fileName: fileName})
+			bigCount ++
+			lineCount ++
+		})
+		log.writeLog(`[INFO] Transform dictonary created for : ${fileName}`)
+	}
+	catch (e)
+	{
+		console.log(`[ERROR] ${e}`)
+	}
+
+	return bigCount;
+
+}
+
+/**
+ * Transforms a file uri to a path
+ * 
+ * @param uri File based Uniform resource identifier
+ * @returns Path in OS style
+ */
+function getPathFromUri(uri : string) : string {
+	let path = uri.replace('file:///', '')
+	path =  path.replace('%3A', ':')
+
+	return path
+}
+
+/**
+ * Transforms a path to a file uri
+ * 
+ * @param path Path of a file
+ * @returns Uniform resource identifier (URI) to the file path
+ */
+function getUriFromPath(path : string) : string  {
+	let tempUri = path.replace(':', '%3A')
+	tempUri = 'file:///'+ + tempUri
+
+	return tempUri
+}


### PR DESCRIPTION
Adds support for sketches with multiple files/tabs.

**Description of the changes**
All the .pde files in a workspace are keyed by there filename with there contents as value in to a contents map. When a file changes, is added or removed the map is updated. When preprocessing starts each line of the contents map is added to a bigcode block. Each line number of the file/tab is keyed to the line number of the big code block. The big code block is then further preprocessed. 

When a server request (definition, diagnostics or reference) is passed by the client. The line number of the big code is converted to the line number of the file/tab it belongs to.

Closes #28

